### PR TITLE
Update template to allow arm64 images and provide docker files for up…

### DIFF
--- a/template/container-image/README.md
+++ b/template/container-image/README.md
@@ -1,0 +1,31 @@
+# Dockerfile and container image
+
+Drupal can run on amd64 or arm64 hosting platforms. AWS ECS Fargate support both
+platforms for linux. In this directory are the container files for building the
+desired custom image. Alternatively, if no cusotmizations or updates are needed
+you can supply the public image name for the target hosting platform.
+
+Supported architectures images can be found on 
+ - [Docker Hub](https://hub.docker.com/_/drupal)
+
+## Build image, tag, and upload to AWS ECR
+
+```bash
+export AWS_ACCOUNT="123456789"
+export AWS_REGION="us-east-1"
+
+aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin "${AWS_ACCOUNT}".dkr.ecr."${AWS_REGION}".amazonaws.com
+docker build -t drupal:v1 .
+docker tag drupal:v1 "${AWS_ACCOUNT}".dkr.ecr."${AWS_REGION}".amazonaws.com/drupal:v1
+docker push "${AWS_ACCOUNT}".dkr.ecr."${AWS_REGION}".amazonaws.com/drupal:v1
+```
+
+> **Note**
+> Running Drupal requires a database such as mysql.
+
+## Run locally
+
+Refer to the section `"How to use this image"` on [drupal - Official image | Docker Hub](https://hub.docker.com/_/drupal)
+
+
+

--- a/template/container-image/amd64/Dockerfile
+++ b/template/container-image/amd64/Dockerfile
@@ -1,0 +1,4 @@
+FROM drupal:8-apache
+RUN apt update && apt upgrade -y
+
+

--- a/template/container-image/arm64/Dockerfile
+++ b/template/container-image/arm64/Dockerfile
@@ -1,0 +1,4 @@
+FROM arm64v8/drupal 
+RUN apt update && apt upgrade -y
+
+

--- a/template/template.yaml
+++ b/template/template.yaml
@@ -1,11 +1,11 @@
 Description: Template to deploy Drupal application on EFS using ECS Fargate
-Metadata: 
-  AWS::CloudFormation::Interface: 
-    ParameterGroups: 
-      - 
-        Label: 
-          default: "Network Configuration"
-        Parameters: 
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Network Configuration
+        Parameters:
           - VpcCIDR
           - PublicSubnet1CIDR
           - PublicSubnet2CIDR
@@ -13,181 +13,200 @@ Metadata:
           - PrivateSubnet1CIDR
           - PrivateSubnet2CIDR
           - PrivateSubnet3CIDR
-      - 
-        Label: 
-          default: "ECS cluster Configuration"
-        Parameters: 
+      - Label:
+          default: ECS cluster Configuration
+        Parameters:
           - ClusterName
           - Image
           - MinCapacity
           - MaxCapacity
-      - 
-        Label: 
-          default: "Amazon Aurora Serverless MySQL DB Configuration"
-        Parameters: 
+          - CpuArchitecture
+      - Label:
+          default: Amazon Aurora Serverless MySQL DB Configuration
+        Parameters:
+          - DBClusterIdentifier
           - DBAdminUsername
           - DBPassword
           - MinimumAuroraCapacityUnit
           - MaximumAuroraCapacityUnit
-      - 
-        Label: 
-          default: "EFS Configuration"
-        Parameters: 
+      - Label:
+          default: EFS Configuration
+        Parameters:
           - PerformanceMode
           - EfsProvisionedThroughputInMibps
           - ThroughputMode
-      - 
-        Label:
-          default: "Tagging Configuration"
+      - Label:
+          default: Tagging Configuration
         Parameters:
           - EnvironmentName
 
 Parameters:
   ClusterName:
-    Type: String 
-    Description: Name for Aurora Cluster DB and EFS. 
-    Default: drupalonefs
-  Image:
+    Description: Name for Aurora Cluster DB and EFS.
     Type: String
-    Default: "drupal:8-apache"
-    Description: Drupal Image for the ECS service. 
+    Default: drupalonefs
+
+  Image:
+    Description: Drupal Image for the ECS service.
+    Type: String
+    Default: drupal:8-apache
+
+  CpuArchitecture:
+    Description: CPU Architecture type ARM64 | X86_64
+    Type: String
+    AllowedValues:
+      - ARM64
+      - X86_64
+    Default: X86_64
+
   MinCapacity:
     Description: Minimum Fargate tasks to run
     Type: Number
     Default: 1
+
   MaxCapacity:
     Description: Maximum Fargate tasks to scale
     Type: Number
     Default: 5
+
   EnvironmentName:
     Description: An environment name that is prefixed to resource names
     Type: String
     Default: Test
+
   VpcCIDR:
     Description: Please enter the IP range (CIDR notation) for this VPC
     Type: String
     Default: 10.192.0.0/16
+
   PublicSubnet1CIDR:
     Description: Please enter the IP range (CIDR notation) for the public subnet in the first Availability Zone
     Type: String
     Default: 10.192.10.0/24
+
   PublicSubnet2CIDR:
     Description: Please enter the IP range (CIDR notation) for the public subnet in the second Availability Zone
     Type: String
     Default: 10.192.11.0/24
+
   PublicSubnet3CIDR:
     Description: Please enter the IP range (CIDR notation) for the public subnet in the second Availability Zone
     Type: String
     Default: 10.192.12.0/24
+
   PrivateSubnet1CIDR:
     Description: Please enter the IP range (CIDR notation) for the private subnet in the first Availability Zone
     Type: String
     Default: 10.192.20.0/24
+
   PrivateSubnet2CIDR:
     Description: Please enter the IP range (CIDR notation) for the private subnet in the second Availability Zone
     Type: String
     Default: 10.192.21.0/24
+
   PrivateSubnet3CIDR:
     Description: Please enter the IP range (CIDR notation) for the private subnet in the second Availability Zone
     Type: String
     Default: 10.192.22.0/24
+
+  DBClusterIdentifier:
+    Description: Please enter a database cluster identifier name
+    Type: String
+    Default: drupal-db-aurora-serverless
+
   DBAdminUsername:
-    Description: Please enter a username for the Aurora DB that will be created as part of this stack. 
+    Description: Please enter a username for the Aurora DB that will be created as part of this stack.
     Type: String
     Default: admin
+
   DBPassword:
-    NoEcho: true
-    Description: Please enter a password for the Aurora DB that will be created as part of this stack. 
+    Description: Please enter a password for the Aurora DB that will be created as part of this stack.
     Type: String
+    NoEcho: true
     MinLength: 8
     MaxLength: 41
+
   MinimumAuroraCapacityUnit:
     Description: Minimum Aurora capacity unit
     Type: Number
     Default: 1
+
   MaximumAuroraCapacityUnit:
     Description: Maximum Aurora capacity unit
     Type: Number
-    Default: 16    
+    Default: 16
+
   PerformanceMode:
     Type: String
-    AllowedValues: [ generalPurpose, maxIO ]
+    AllowedValues: [generalPurpose, maxIO]
     Default: generalPurpose
+
   EfsProvisionedThroughputInMibps:
     Type: Number
+    Default: 0
     MinValue: 0
     MaxValue: 1024
-    Default: 0
+
   ThroughputMode:
     Type: String
-    AllowedValues: [ bursting, provisioned ]
+    AllowedValues: [bursting, provisioned]
     Default: bursting
-Rules:
-  ProvisionedThroughput:
-    RuleCondition: !Equals [ !Ref ThroughputMode, provisioned ]
-    Assertions:
-      - Assert: !Not [ !Equals [ '0', !Ref EfsProvisionedThroughputInMibps ] ]
-        AssertDescription: "EfsProvisionedThroughputInMibps must be greater than 0 when ThroughputMode is provisioned"
-  BurstingThroughput:
-    RuleCondition: !Equals [ !Ref ThroughputMode, bursting ]
-    Assertions:
-      - Assert:  !Equals [ '0', !Ref EfsProvisionedThroughputInMibps ]
-        AssertDescription: "EfsProvisionedThroughputInMibps must be 0 when ThroughputMode is bursting"
-Conditions:
-  IsProvisioned:
-    !Equals [ !Ref ThroughputMode, provisioned ]
 
 Mappings:
   RegionMap:
     us-east-1:
-      "elbAcc" : "127311923021"
+      elbAcc: "127311923021"
     us-east-2:
-      "elbAcc" : "033677994240"
+      elbAcc: "033677994240"
     us-west-1:
-      "elbAcc" : "027434742980"
+      elbAcc: "027434742980"
     us-west-2:
-      "elbAcc" : "797873946194"
+      elbAcc: "797873946194"
     af-south-1:
-      "elbAcc" : "098369216593"
+      elbAcc: "098369216593"
     ca-central-1:
-      "elbAcc" : "985666609251"
+      elbAcc: "985666609251"
     eu-central-1:
-      "elbAcc" : "054676820928"
+      elbAcc: "054676820928"
     eu-west-1:
-      "elbAcc" : "156460612806"
+      elbAcc: "156460612806"
     eu-west-2:
-      "elbAcc" : "652711504416"
+      elbAcc: "652711504416"
     eu-south-1:
-      "elbAcc" : "635631232127"
+      elbAcc: "635631232127"
     eu-west-3:
-      "elbAcc" : "009996457667"
+      elbAcc: "009996457667"
     eu-north-1:
-      "elbAcc" : "897822967062"
+      elbAcc: "897822967062"
     ap-east-1:
-      "elbAcc" : "754344448648"
+      elbAcc: "754344448648"
     ap-northeast-1:
-      "elbAcc" : "582318560864"
+      elbAcc: "582318560864"
     ap-northeast-2:
-      "elbAcc" : "600734575887"
+      elbAcc: "600734575887"
     ap-northeast-3:
-      "elbAcc" : "383597477331"
+      elbAcc: "383597477331"
     ap-southeast-1:
-      "elbAcc" : "114774131450"
+      elbAcc: "114774131450"
     ap-southeast-2:
-      "elbAcc" : "783225319266"
+      elbAcc: "783225319266"
     ap-south-1:
-      "elbAcc" : "718504428378"
+      elbAcc: "718504428378"
     me-south-1:
-      "elbAcc" : "076674570225"
+      elbAcc: "076674570225"
     sa-east-1:
-      "elbAcc" : "507241528517"
+      elbAcc: "507241528517"
     us-gov-west-1:
-      "elbAcc" : "048591011584"
+      elbAcc: "048591011584"
     us-gov-east-1:
-      "elbAcc" : "190560391635"
-  
+      elbAcc: "190560391635"
+
+Conditions:
+  IsProvisioned: !Equals [!Ref ThroughputMode, provisioned]
+
 Resources:
   #VPC resources
+
   VPC:
     Type: AWS::EC2::VPC
     Properties:
@@ -197,14 +216,17 @@ Resources:
       Tags:
         - Key: Name
           Value: !Ref EnvironmentName
+
   vpcFlowLog:
     Type: AWS::EC2::FlowLog
     Properties:
-      LogDestination: !Join ['/',[!GetAtt loadbalancerLogBucket.Arn,vpcflowlogs]]
+      LogDestination:
+        !Join [/, [!GetAtt loadbalancerLogBucket.Arn, vpcflowlogs]]
       LogDestinationType: s3
       ResourceId: !Ref VPC
       ResourceType: VPC
       TrafficType: REJECT
+
   InternetGateway:
     Type: AWS::EC2::InternetGateway
     Properties:
@@ -222,7 +244,7 @@ Resources:
     Type: AWS::EC2::Subnet
     Properties:
       VpcId: !Ref VPC
-      AvailabilityZone: !Select [ 0, !GetAZs '' ]
+      AvailabilityZone: !Select [0, !GetAZs ""]
       CidrBlock: !Ref PublicSubnet1CIDR
       MapPublicIpOnLaunch: false
       Tags:
@@ -233,18 +255,18 @@ Resources:
     Type: AWS::EC2::Subnet
     Properties:
       VpcId: !Ref VPC
-      AvailabilityZone: !Select [ 1, !GetAZs  '' ]
+      AvailabilityZone: !Select [1, !GetAZs ""]
       CidrBlock: !Ref PublicSubnet2CIDR
       MapPublicIpOnLaunch: false
       Tags:
         - Key: Name
           Value: !Sub ${EnvironmentName} Public Subnet (AZ2)
-  
+
   PublicSubnet3:
     Type: AWS::EC2::Subnet
     Properties:
       VpcId: !Ref VPC
-      AvailabilityZone: !Select [ 2, !GetAZs  '' ]
+      AvailabilityZone: !Select [2, !GetAZs ""]
       CidrBlock: !Ref PublicSubnet3CIDR
       MapPublicIpOnLaunch: false
       Tags:
@@ -255,7 +277,7 @@ Resources:
     Type: AWS::EC2::Subnet
     Properties:
       VpcId: !Ref VPC
-      AvailabilityZone: !Select [ 0, !GetAZs  '' ]
+      AvailabilityZone: !Select [0, !GetAZs ""]
       CidrBlock: !Ref PrivateSubnet1CIDR
       MapPublicIpOnLaunch: false
       Tags:
@@ -266,7 +288,7 @@ Resources:
     Type: AWS::EC2::Subnet
     Properties:
       VpcId: !Ref VPC
-      AvailabilityZone: !Select [ 1, !GetAZs  '' ]
+      AvailabilityZone: !Select [1, !GetAZs ""]
       CidrBlock: !Ref PrivateSubnet2CIDR
       MapPublicIpOnLaunch: false
       Tags:
@@ -277,13 +299,12 @@ Resources:
     Type: AWS::EC2::Subnet
     Properties:
       VpcId: !Ref VPC
-      AvailabilityZone: !Select [ 2, !GetAZs  '' ]
+      AvailabilityZone: !Select [2, !GetAZs ""]
       CidrBlock: !Ref PrivateSubnet3CIDR
       MapPublicIpOnLaunch: false
       Tags:
         - Key: Name
           Value: !Sub ${EnvironmentName} Private Subnet (AZ3)
-
 
   NatGateway1EIP:
     Type: AWS::EC2::EIP
@@ -296,7 +317,7 @@ Resources:
     DependsOn: InternetGatewayAttachment
     Properties:
       Domain: vpc
-  
+
   NatGateway3EIP:
     Type: AWS::EC2::EIP
     DependsOn: InternetGatewayAttachment
@@ -355,7 +376,6 @@ Resources:
       RouteTableId: !Ref PublicRouteTable
       SubnetId: !Ref PublicSubnet3
 
-
   PrivateRouteTable1:
     Type: AWS::EC2::RouteTable
     Properties:
@@ -397,7 +417,7 @@ Resources:
     Properties:
       RouteTableId: !Ref PrivateRouteTable2
       SubnetId: !Ref PrivateSubnet2
-  
+
   PrivateRouteTable3:
     Type: AWS::EC2::RouteTable
     Properties:
@@ -420,10 +440,11 @@ Resources:
       SubnetId: !Ref PrivateSubnet3
 
   #DB Resources
+
   DrupalDBSubnetGroupName:
     Type: AWS::RDS::DBSubnetGroup
     Properties:
-      DBSubnetGroupDescription: "DrupalDB SubnetGroupName"
+      DBSubnetGroupDescription: DrupalDB SubnetGroupName
       SubnetIds:
         - !Ref PrivateSubnet1
         - !Ref PrivateSubnet2
@@ -432,27 +453,27 @@ Resources:
   DrupalDBSG:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: "Enable DB access via port 3306"
+      GroupDescription: Enable DB access via port 3306
       #GroupName: "Drupal DB SG"
       SecurityGroupIngress:
         - CidrIp: !Ref VpcCIDR
           IpProtocol: tcp
           FromPort: 3306
           ToPort: 3306
-          Description: "Provide DB access via port 3306"
+          Description: Provide DB access via port 3306
       SecurityGroupEgress:
         - CidrIp: !Ref VpcCIDR
           IpProtocol: tcp
           FromPort: 3306
           ToPort: 3306
-          Description: "Provide DB access via port 3306"
+          Description: Provide DB access via port 3306
       VpcId: !Ref VPC
 
   DrupalDB:
     Type: AWS::RDS::DBCluster
     Properties:
       DatabaseName: drupal
-      DBClusterIdentifier: drupal-db-aurora-serverless
+      DBClusterIdentifier: !Ref DBClusterIdentifier
       DBSubnetGroupName: !Ref DrupalDBSubnetGroupName
       Engine: aurora-mysql
       EngineMode: serverless
@@ -468,24 +489,26 @@ Resources:
         SecondsUntilAutoPause: 1000
 
   #EFS Resources
+
   EFSSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: "Enable EFS access via port 2049"
+      GroupDescription: Enable EFS access via port 2049
       #GroupName: "Drupal EFS SG"
       SecurityGroupIngress:
         - CidrIp: !Ref VpcCIDR
           IpProtocol: tcp
           FromPort: 2049
           ToPort: 2049
-          Description: "For enabling EFS access"
+          Description: For enabling EFS access
       SecurityGroupEgress:
         - CidrIp: !Ref VpcCIDR
           IpProtocol: tcp
           FromPort: 2049
           ToPort: 2049
-          Description: "For enabling EFS access"
+          Description: For enabling EFS access
       VpcId: !Ref VPC
+
   EFSFileSystem:
     Type: AWS::EFS::FileSystem
     Properties:
@@ -494,106 +517,119 @@ Resources:
       FileSystemPolicy:
         Version: "2012-10-17"
         Statement:
-          - Effect: "Allow"
+          - Effect: Allow
             Action:
               - elasticfilesystem:ClientMount
               - elasticfilesystem:ClientRootAccess
               - elasticfilesystem:ClientWrite
             Principal:
-                AWS: !GetAtt ECSTaskRole.Arn
-      ProvisionedThroughputInMibps: !If [ IsProvisioned, !Ref EfsProvisionedThroughputInMibps, !Ref 'AWS::NoValue' ]
+              AWS: !GetAtt ECSTaskRole.Arn
+      ProvisionedThroughputInMibps:
+        !If [
+          IsProvisioned,
+          !Ref EfsProvisionedThroughputInMibps,
+          !Ref "AWS::NoValue",
+        ]
       ThroughputMode: !Ref ThroughputMode
       FileSystemTags:
         - Key: Name
           Value: !Ref ClusterName
+
   MountTargetPrivateSubnet1:
     Type: AWS::EFS::MountTarget
     Properties:
       FileSystemId: !Ref EFSFileSystem
-      SecurityGroups: [ !Ref EFSSecurityGroup ]
+      SecurityGroups: [!Ref EFSSecurityGroup]
       SubnetId: !Ref PrivateSubnet1
+
   MountTargetPrivateSubnet2:
     Type: AWS::EFS::MountTarget
     Properties:
       FileSystemId: !Ref EFSFileSystem
-      SecurityGroups: [ !Ref EFSSecurityGroup ]
+      SecurityGroups: [!Ref EFSSecurityGroup]
       SubnetId: !Ref PrivateSubnet2
+
   MountTargetPrivateSubnet3:
     Type: AWS::EFS::MountTarget
     Properties:
       FileSystemId: !Ref EFSFileSystem
-      SecurityGroups: [ !Ref EFSSecurityGroup ]
+      SecurityGroups: [!Ref EFSSecurityGroup]
       SubnetId: !Ref PrivateSubnet3
+
   AccessPointSites:
-      Type: 'AWS::EFS::AccessPoint'
-      Properties:
-        AccessPointTags: 
-          - Key: "Name"
-            Value: "sites"
-        FileSystemId: !Ref EFSFileSystem
-        PosixUser:
-          Uid: "33"
-          Gid: "33"
-        RootDirectory:
-          CreationInfo:
-            OwnerGid: "33"
-            OwnerUid: "33"
-            Permissions: "0755"
-          Path: "/sites"  
+    Type: AWS::EFS::AccessPoint
+    Properties:
+      AccessPointTags:
+        - Key: Name
+          Value: sites
+      FileSystemId: !Ref EFSFileSystem
+      PosixUser:
+        Uid: "33"
+        Gid: "33"
+      RootDirectory:
+        CreationInfo:
+          OwnerGid: "33"
+          OwnerUid: "33"
+          Permissions: "0755"
+        Path: /sites
+
   AccessPointModules:
-      Type: 'AWS::EFS::AccessPoint'
-      Properties:
-        AccessPointTags: 
-          - Key: "Name"
-            Value: "modules"    
-        FileSystemId: !Ref EFSFileSystem
-        PosixUser:
-          Uid: "33"
-          Gid: "33"
-        RootDirectory:
-          CreationInfo:
-            OwnerGid: "33"
-            OwnerUid: "33"
-            Permissions: "0755"
-          Path: "/modules"  
+    Type: AWS::EFS::AccessPoint
+    Properties:
+      AccessPointTags:
+        - Key: Name
+          Value: modules
+      FileSystemId: !Ref EFSFileSystem
+      PosixUser:
+        Uid: "33"
+        Gid: "33"
+      RootDirectory:
+        CreationInfo:
+          OwnerGid: "33"
+          OwnerUid: "33"
+          Permissions: "0755"
+        Path: /modules
+
   AccessPointThemes:
-      Type: 'AWS::EFS::AccessPoint'
-      Properties:
-        AccessPointTags: 
-          - Key: "Name"
-            Value: "themes"   
-        FileSystemId: !Ref EFSFileSystem
-        PosixUser:
-          Uid: "33"
-          Gid: "33"
-        RootDirectory:
-          CreationInfo:
-            OwnerGid: "33"
-            OwnerUid: "33"
-            Permissions: "0755"
-          Path: "/themes"  
+    Type: AWS::EFS::AccessPoint
+    Properties:
+      AccessPointTags:
+        - Key: Name
+          Value: themes
+      FileSystemId: !Ref EFSFileSystem
+      PosixUser:
+        Uid: "33"
+        Gid: "33"
+      RootDirectory:
+        CreationInfo:
+          OwnerGid: "33"
+          OwnerUid: "33"
+          Permissions: "0755"
+        Path: /themes
+
   AccessPointProfiles:
-      Type: 'AWS::EFS::AccessPoint'
-      Properties:
-        AccessPointTags: 
-          - Key: "Name"
-            Value: "profiles"     
-        FileSystemId: !Ref EFSFileSystem
-        PosixUser:
-          Uid: "33"
-          Gid: "33"        
-        RootDirectory:
-          CreationInfo:
-            OwnerGid: "33"
-            OwnerUid: "33"
-            Permissions: "0755"
-          Path: "/profiles"   
-                                       
+    Type: AWS::EFS::AccessPoint
+    Properties:
+      AccessPointTags:
+        - Key: Name
+          Value: profiles
+      FileSystemId: !Ref EFSFileSystem
+      PosixUser:
+        Uid: "33"
+        Gid: "33"
+      RootDirectory:
+        CreationInfo:
+          OwnerGid: "33"
+          OwnerUid: "33"
+          Permissions: "0755"
+        Path: /profiles
+
   #ECS Resources
+
   cluster:
     Type: AWS::ECS::Cluster
     Properties:
-      ClusterName: !Join ['-', [!Ref ClusterName, Cluster]] 
+      ClusterName: !Join ["-", [!Ref ClusterName, Cluster]]
       ClusterSettings:
         - Name: containerInsights
           Value: enabled
@@ -607,10 +643,10 @@ Resources:
           - Effect: Allow
             Principal:
               Service: ecs-tasks.amazonaws.com
-            Action: 'sts:AssumeRole'
+            Action: sts:AssumeRole
       ManagedPolicyArns:
-        - 'arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy'
-        
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+
   ECSTaskRole:
     Type: AWS::IAM::Role
     Properties:
@@ -620,23 +656,22 @@ Resources:
           - Effect: Allow
             Principal:
               Service: ecs-tasks.amazonaws.com
-            Action: 'sts:AssumeRole'
+            Action: sts:AssumeRole
       Policies:
         - PolicyName: EFSAccess
           PolicyDocument:
-            Version: '2012-10-17'
+            Version: "2012-10-17"
             Statement:
               - Effect: Allow
-                Action: 
-                 - elasticfilesystem:ClientMount
-                 - elasticfilesystem:ClientRootAccess                 
-                 - elasticfilesystem:ClientWrite
-                Resource: '*'
+                Action:
+                  - elasticfilesystem:ClientMount
+                  - elasticfilesystem:ClientRootAccess
+                  - elasticfilesystem:ClientWrite
+                Resource: "*"
                 Condition:
                   StringEquals:
-                    'aws:TagKeys/Name': !Ref ClusterName
-              
-      
+                    aws:TagKeys/Name: !Ref ClusterName
+
   AutoScalingRole:
     Type: AWS::IAM::Role
     Properties:
@@ -646,16 +681,16 @@ Resources:
           - Effect: Allow
             Principal:
               Service: ecs-tasks.amazonaws.com
-            Action: 'sts:AssumeRole'
+            Action: sts:AssumeRole
       ManagedPolicyArns:
-        - 'arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceAutoscaleRole'
+        - arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceAutoscaleRole
 
   AutoScalingTarget:
     Type: AWS::ApplicationAutoScaling::ScalableTarget
     Properties:
       MinCapacity: !Ref MinCapacity
       MaxCapacity: !Ref MaxCapacity
-      ResourceId: !Join ['/', [service, !Ref cluster, !GetAtt service.Name]]
+      ResourceId: !Join [/, [service, !Ref cluster, !GetAtt service.Name]]
       ScalableDimension: ecs:service:DesiredCount
       ServiceNamespace: ecs
       RoleARN: !GetAtt AutoScalingRole.Arn
@@ -663,7 +698,7 @@ Resources:
   AutoScalingPolicy:
     Type: AWS::ApplicationAutoScaling::ScalingPolicy
     Properties:
-      PolicyName: !Join ['', [!Ref ClusterName, AutoScalingPolicy]]
+      PolicyName: !Join ["", [!Ref ClusterName, AutoScalingPolicy]]
       PolicyType: TargetTrackingScaling
       ScalingTargetId: !Ref AutoScalingTarget
       TargetTrackingScalingPolicyConfiguration:
@@ -676,19 +711,19 @@ Resources:
 
   service:
     Type: AWS::ECS::Service
-    DependsOn: 
-    - listener
+    DependsOn:
+      - listener
     Properties:
-      ServiceName: !Join ['-',[!Ref ClusterName, service]]
+      ServiceName: !Join ["-", [!Ref ClusterName, service]]
       Cluster: !Ref cluster
       TaskDefinition: !Ref taskdefinition
       EnableExecuteCommand: true
       DeploymentConfiguration:
-          MinimumHealthyPercent: 100
-          MaximumPercent: 200
+        MinimumHealthyPercent: 100
+        MaximumPercent: 200
       DesiredCount: !Ref MinCapacity
       LaunchType: FARGATE
-      NetworkConfiguration: 
+      NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: DISABLED
           Subnets:
@@ -698,31 +733,32 @@ Resources:
           SecurityGroups:
             - !Ref containersecuritygroup
       LoadBalancers:
-        - ContainerName: "drupal"
+        - ContainerName: drupal
           ContainerPort: 80
           TargetGroupArn: !Ref targetgroup
-    
+
   targetgroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     DependsOn: loadbalancer
     Properties:
       TargetGroupAttributes:
-      - Key: stickiness.enabled
-        Value: "true"
-      - Key: stickiness.type
-        Value: lb_cookie 
+        - Key: stickiness.enabled
+          Value: "true"
+        - Key: stickiness.type
+          Value: lb_cookie
       HealthCheckIntervalSeconds: 60
       HealthCheckPath: /
       HealthCheckTimeoutSeconds: 30
       UnhealthyThresholdCount: 5
       HealthyThresholdCount: 2
       Matcher:
-        HttpCode: "200,302"
-      Name: !Join ['-', [!Ref ClusterName, TargetGroup]]
+        HttpCode: 200,302
+      Name: !Join ["-", [!Ref ClusterName, TargetGroup]]
       Port: 80
       Protocol: HTTP
       TargetType: ip
       VpcId: !Ref VPC
+
   listener:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:
@@ -734,58 +770,56 @@ Resources:
       Protocol: HTTP
 
   loadbalancerLogBucket:
-    Type: 'AWS::S3::Bucket'
+    Type: AWS::S3::Bucket
     Properties:
       BucketName: !Join
-        - '-'
+        - "-"
         - - !Ref ClusterName
-          - 'loadbalancer'
-          - 'logs'
-          - !Ref 'AWS::AccountId'
-          - !Ref 'AWS::Region'
+          - loadbalancer
+          - logs
+          - !Ref "AWS::AccountId"
+          - !Ref "AWS::Region"
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
-  
+
   loadbalancerLogBucketPolicy:
-    Type: 'AWS::S3::BucketPolicy'
+    Type: AWS::S3::BucketPolicy
     Properties:
       Bucket: !Ref loadbalancerLogBucket
       PolicyDocument:
         Statement:
-          - Action: 's3:PutObject'
-            Effect: 'Allow'
+          - Action: s3:PutObject
+            Effect: Allow
             Resource: !Join
-              - ''
-              - - 'arn:aws:s3:::'
+              - ""
+              - - "arn:aws:s3:::"
                 - !Ref loadbalancerLogBucket
                 - /*
-            Principal: 
+            Principal:
               AWS: !Join
-                - ''
-                - - 'arn:aws:iam::'
+                - ""
+                - - "arn:aws:iam::"
                   - !FindInMap [RegionMap, !Ref "AWS::Region", elbAcc]
-                  - ':root'
-          - Action: 's3:PutObject'
-            Effect: 'Allow'
+                  - :root
+          - Action: s3:PutObject
+            Effect: Allow
             Resource: !Join
-              - ''
-              - - 'arn:aws:s3:::'
+              - ""
+              - - "arn:aws:s3:::"
                 - !Ref loadbalancerLogBucket
                 - /*
             Principal:
               Service: delivery.logs.amazonaws.com
-          - Action: 's3:GetBucketAcl'
-            Effect: 'Allow'
+          - Action: s3:GetBucketAcl
+            Effect: Allow
             Resource: !Join
-              - ''
-              - - 'arn:aws:s3:::'
+              - ""
+              - - "arn:aws:s3:::"
                 - !Ref loadbalancerLogBucket
             Principal:
               Service: delivery.logs.amazonaws.com
-              
-
 
   loadbalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
@@ -807,100 +841,98 @@ Resources:
   containersecuritygroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: !Join ['-', [!Ref ClusterName, ContainerSecurityGroup]]
+      GroupDescription: !Join ["-", [!Ref ClusterName, ContainerSecurityGroup]]
       VpcId: !Ref VPC
       SecurityGroupIngress:
         - IpProtocol: tcp
           FromPort: 80
           ToPort: 80
           SourceSecurityGroupId: !Ref albsecuritygroup
-          Description: "Container security group Ingress rule"
+          Description: Container security group Ingress rule
       SecurityGroupEgress:
         - CidrIp: 0.0.0.0/0
           IpProtocol: tcp
           FromPort: 443
           ToPort: 443
-          Description: "Container security group Egress rule"
-  
+          Description: Container security group Egress rule
+
   containersecuritygroupEgressRuleEFS:
     Type: AWS::EC2::SecurityGroupEgress
-    Properties: 
+    Properties:
       CidrIp: !Ref VpcCIDR
-      Description: Container security group egress rule to access the EFS resources. 
+      Description: Container security group egress rule to access the EFS resources.
       FromPort: 2049
       IpProtocol: tcp
       ToPort: 2049
       GroupId: !Ref containersecuritygroup
+
   containersecuritygroupEgressRuleAurora:
     Type: AWS::EC2::SecurityGroupEgress
-    Properties: 
+    Properties:
       CidrIp: !Ref VpcCIDR
-      Description: Container security group egress rule to access the EFS resources. 
+      Description: Container security group egress rule to access the EFS resources.
       FromPort: 3306
       IpProtocol: tcp
       ToPort: 3306
       GroupId: !Ref containersecuritygroup
 
-
-
-
   albsecuritygroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: !Join ['-', [!Ref ClusterName, LoadBalancerSecurityGroup]]
+      GroupDescription:
+        !Join ["-", [!Ref ClusterName, LoadBalancerSecurityGroup]]
       VpcId: !Ref VPC
       SecurityGroupIngress:
         - IpProtocol: tcp
           FromPort: 80
           ToPort: 80
           CidrIp: 0.0.0.0/0
-          Description: "ALB security group Ingress rule"
+          Description: ALB security group Ingress rule
       SecurityGroupEgress:
         - CidrIp: !Ref VpcCIDR
           IpProtocol: tcp
           FromPort: 80
           ToPort: 80
-          Description: "ALB security group Egress"
+          Description: ALB security group Egress
 
   loggroupKmskey:
     Type: AWS::KMS::Key
-    Properties: 
+    Properties:
       Description: KMS key to encrypt the CloudWatch LogGroup
       Enabled: true
       EnableKeyRotation: true
       KeyPolicy:
-        Version: '2012-10-17'
+        Version: "2012-10-17"
         Id: key-default-1
         Statement:
-        - Sid: Enable IAM User Permissions
-          Effect: Allow
-          Principal:
-            AWS: !Join ['',['arn:aws:iam::',!Ref AWS::AccountId,':root']]
-          Action: kms:*
-          Resource: '*'
-        - Sid: Enabled CloudWatch to access KMS
-          Effect: Allow
-          Principal:
-            Service: !Join ['',['logs.',!Ref AWS::Region,'.amazonaws.com']]
-          Action:
-            - kms:Encrypt*
-            - kms:Decrypt*
-            - kms:ReEncrypt*
-            - kms:GenerateDataKey*
-            - kms:Describe*
-          Resource: '*'
-        - Sid: Allow ELB logs to be sent to S3
-          Effect: Allow
-          Principal:
-            Service: delivery.logs.amazonaws.com
-          Action:
-            - kms:Encrypt*
-            - kms:Decrypt*
-            - kms:ReEncrypt*
-            - kms:GenerateDataKey*
-            - kms:Describe*
-          Resource: '*'
-
+          - Sid: Enable IAM User Permissions
+            Effect: Allow
+            Principal:
+              AWS: !Join ["", ["arn:aws:iam::", !Ref "AWS::AccountId", ":root"]]
+            Action: kms:*
+            Resource: "*"
+          - Sid: Enabled CloudWatch to access KMS
+            Effect: Allow
+            Principal:
+              Service: !Join ["", [logs., !Ref "AWS::Region", .amazonaws.com]]
+            Action:
+              - kms:Encrypt*
+              - kms:Decrypt*
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:Describe*
+            Resource: "*"
+          - Sid: Allow ELB logs to be sent to S3
+            Effect: Allow
+            Principal:
+              Service: delivery.logs.amazonaws.com
+            Action:
+              - kms:Encrypt*
+              - kms:Decrypt*
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:Describe*
+            Resource: "*"
       #KeySpec: String
       #KeyUsage: String
       PendingWindowInDays: 7
@@ -908,25 +940,27 @@ Resources:
   LogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Join ['', [/ecs/, !Ref ClusterName, taskdefinition]]
+      LogGroupName: !Join ["", [/ecs/, !Ref ClusterName, taskdefinition]]
       RetentionInDays: 30
       KmsKeyId: !GetAtt loggroupKmskey.Arn
 
-  taskdefinition: 
+  taskdefinition:
     Type: AWS::ECS::TaskDefinition
-    Properties: 
+    Properties:
       RequiresCompatibilities:
-        - "EC2"
-        - "FARGATE"
-      Family: !Join ["-",[!Ref ClusterName,td]]
+        - EC2
+        - FARGATE
+      RuntimePlatform:
+        OperatingSystemFamily: LINUX
+        CpuArchitecture: !Ref CpuArchitecture
+      Family: !Join ["-", [!Ref ClusterName, td]]
       ExecutionRoleArn: !GetAtt ExecutionRole.Arn
       TaskRoleArn: !GetAtt ECSTaskRole.Arn
       ContainerDefinitions:
-        -
-          EntryPoint:
-            - "sh"
-            - "-c"
-            - "cp -prR /var/www/html/sites/* /mnt"
+        - EntryPoint:
+            - sh
+            - -c
+            - cp -prR /var/www/html/sites/* /mnt
           Essential: false
           Image: !Ref Image
           LogConfiguration:
@@ -936,94 +970,83 @@ Resources:
               awslogs-group: !Ref LogGroup
               awslogs-stream-prefix: ecs
           MountPoints:
-            - 
-              ContainerPath: "/mnt"
-              SourceVolume: "sites"
-          Name: "initcontainer"
-        -
-          DependsOn:
-            -
-              Condition: "COMPLETE"
-              ContainerName: "initcontainer"
+            - ContainerPath: /mnt
+              SourceVolume: sites
+          Name: initcontainer
+        - DependsOn:
+            - Condition: COMPLETE
+              ContainerName: initcontainer
           Essential: true
           Image: !Ref Image
           MountPoints:
-            -
-              ContainerPath: "/var/www/html/modules/"
-              SourceVolume: "modules"
-            
-            - 
-              ContainerPath: "/var/www/html/sites/"
-              SourceVolume: "sites"
-
-            - 
-              ContainerPath: "/var/www/html/profiles/"
-              SourceVolume: "profiles"
-
-            - 
-              ContainerPath: "/var/www/html/themes/"
-              SourceVolume: "themes"
-          Name: "drupal"
+            - ContainerPath: /var/www/html/modules/
+              SourceVolume: modules
+            - ContainerPath: /var/www/html/sites/
+              SourceVolume: sites
+            - ContainerPath: /var/www/html/profiles/
+              SourceVolume: profiles
+            - ContainerPath: /var/www/html/themes/
+              SourceVolume: themes
+          Name: drupal
           PortMappings:
-            -
-              ContainerPort: 80
+            - ContainerPort: 80
               HostPort: 80
               Protocol: tcp
-
       Cpu: "512"
       Memory: "1024"
       NetworkMode: awsvpc
       Volumes:
-        - 
-          Name: themes
+        - Name: themes
           EFSVolumeConfiguration:
             FilesystemId: !Ref EFSFileSystem
             AuthorizationConfig:
               IAM: ENABLED
               AccessPointId: !Ref AccessPointThemes
             TransitEncryption: ENABLED
-            RootDirectory: "/"
-          
-        
-        -
-          Name: profiles
+            RootDirectory: /
+        - Name: profiles
           EFSVolumeConfiguration:
             FilesystemId: !Ref EFSFileSystem
             AuthorizationConfig:
               IAM: ENABLED
               AccessPointId: !Ref AccessPointProfiles
             TransitEncryption: ENABLED
-            RootDirectory: "/"
-          
-
-        -
-          EFSVolumeConfiguration:
+            RootDirectory: /
+        - EFSVolumeConfiguration:
             FilesystemId: !Ref EFSFileSystem
             AuthorizationConfig:
               IAM: ENABLED
               AccessPointId: !Ref AccessPointSites
             TransitEncryption: ENABLED
-            RootDirectory: "/"
+            RootDirectory: /
           Name: sites
-
-        -
-          EFSVolumeConfiguration:
+        - EFSVolumeConfiguration:
             FilesystemId: !Ref EFSFileSystem
             AuthorizationConfig:
               IAM: ENABLED
               AccessPointId: !Ref AccessPointModules
             TransitEncryption: ENABLED
-            RootDirectory: "/"
+            RootDirectory: /
           Name: modules
-
 
 Outputs:
   ALBEndpoint:
-    Description: "ALB endpoint"
-    Value: 
-      !GetAtt loadbalancer.DNSName
-  DBEndpoint:
-    Description: "DB endpoint"
-    Value: 
-      !GetAtt DrupalDB.Endpoint.Address
+    Description: ALB endpoint
+    Value: !GetAtt loadbalancer.DNSName
 
+  DBEndpoint:
+    Description: DB endpoint
+    Value: !GetAtt DrupalDB.Endpoint.Address
+
+Rules:
+  ProvisionedThroughput:
+    RuleCondition: !Equals [!Ref ThroughputMode, provisioned]
+    Assertions:
+      - Assert: !Not [!Equals ["0", !Ref EfsProvisionedThroughputInMibps]]
+        AssertDescription: EfsProvisionedThroughputInMibps must be greater than 0 when ThroughputMode is provisioned
+
+  BurstingThroughput:
+    RuleCondition: !Equals [!Ref ThroughputMode, bursting]
+    Assertions:
+      - Assert: !Equals ["0", !Ref EfsProvisionedThroughputInMibps]
+        AssertDescription: EfsProvisionedThroughputInMibps must be 0 when ThroughputMode is bursting


### PR DESCRIPTION
…dating

*Issue #, if available:*
N/A

*Description of changes:*
- Updated to allow Amazon ECS support using 64-bit ARM applications. 
- Added example Dockerfiles for updates if desired
- Added troubleshooting section based on issue encountered during standard install
- Added `DBClusterIdentifier` for allowing multiple runs of the template and unique Aurora cluster names
- Ran `cfn-format` on template.yaml
- Checked with `cfn-lint`
- tested deploy on ECS Fargate ARM64 configuration

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
